### PR TITLE
Fix wrong match information in JSON renderer 

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,21 +64,21 @@ The `JSON` renderer will print a JSON array with match information for each pack
     "name": "blessed",
     "packageVersion": "0.1.81",
     "installedVersion": "0.1.81",
-    "matches": false,
+    "matches": true,
     "locked": false
   },
   {
     "name": "chalk",
     "packageVersion": "1.1.3",
     "installedVersion": "1.1.3",
-    "matches": false,
+    "matches": true,
     "locked": false
   },
   {
     "name": "jest",
     "packageVersion": "18.1.0",
     "installedVersion": "18.1.0",
-    "matches": false,
+    "matches": true,
     "locked": false
   }
 ]

--- a/src/renderers/json.ts
+++ b/src/renderers/json.ts
@@ -30,6 +30,6 @@ let createMatchInfos = (pkgDescriptor: IPackageDescriptor[]): IPackageMatchInfo[
     name: pkg.name,
     packageVersion: pkg.parsedDefinedVersion,
     installedVersion: pkg.installedVersion,
-    matches: pkg.parsedDefinedVersion !== pkg.installedVersion,
+    matches: pkg.parsedDefinedVersion === pkg.installedVersion,
     locked: pkg.locked
   }));


### PR DESCRIPTION
Looks like we missed this in the last PR. The logic for _matches_ was the wrong way round.