### PR TITLE
New "Strict" CLI option for CI builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,11 @@ NPM Vet is a simple CLI tool to help vet your npm package versions. NPM Vet can 
       -p, --package <package>    package.json file location (Default: .)
       -m, --modules <modules>    node_modules folder location (Default: .)
       -r, --renderer <renderer>  Renderer to use (Default: inlinetable)
+      -s, --strict               Using the CI renderer, fail build if any packages unlocked (Default: false, flag)
+
+## Strict Mode
+
+If you're using the CI renderer (see below) the `-s` flag will enable strict mode. In which builds will fail if versions are unlocked, not just unmatching.
 
 ## Renderers
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "npmvet",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "A simple CLI tool for vetting npm package versions",
   "main": "dist/index.js",
   "scripts": {

--- a/src/cliopts.ts
+++ b/src/cliopts.ts
@@ -8,9 +8,12 @@ import * as program from 'commander';
 export function getCLIOptions(prog: program.ICommand): ICLIOpts
 {
   let opts: ICLIOpts = {
-    package  : prog['package'],
-    modules  : prog['modules'],
-    renderer : prog['renderer']
+    package        : prog['package'],
+    modules        : prog['modules'],
+    renderer       : prog['renderer'],
+    strict         : typeof prog['strict'] === 'boolean'
+                       ? prog['strict']
+                       : false
   };
 
   return opts;

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,7 +23,8 @@ program
   .version(vetPkgFile.version)
   .option('-p, --package <package>', 'package.json file location', '')
   .option('-m, --modules <modules>', 'node_modules folder location', '')
-  .option('-r, --renderer <renderer>', 'Renderer to use', 'inlinetable');
+  .option('-r, --renderer <renderer>', 'Renderer to use', 'inlinetable')
+  .option('-s, --strict', 'Using the CI renderer, fail build if any packages unlocked');
 
 /*
  * Setup the paths using the CLI options and

--- a/src/interfaces/ICLIOpts.ts
+++ b/src/interfaces/ICLIOpts.ts
@@ -6,4 +6,6 @@ interface ICLIOpts
   package: string;
 
   renderer: string;
+
+  strict: boolean;
 };

--- a/src/renderers/ci.ts
+++ b/src/renderers/ci.ts
@@ -4,46 +4,98 @@ import { render as inlineTableRenderer } from './inlinetable';
 
 import { isMatchingVersion } from '../deps';
 
-export const render: IRenderer = (depMap) =>
+export const render: IRenderer = (depMap, cliOpts) =>
 {
   /*
    * Filter packages to only the ones where versions mismatch
    */
-  const filtered: IPackageDescriptorMap = {
+  const filteredMatching: IPackageDescriptorMap = {
     deps    : filterMatchingDependencies(depMap.deps),
     devDeps : filterMatchingDependencies(depMap.devDeps)
   };
 
+  const filteredUnlocked: IPackageDescriptorMap = {
+    deps : filterLockedDependencies(depMap.deps),
+    devDeps : filterLockedDependencies(depMap.devDeps)
+  };
+
+
   /*
-   * Do we have any mismatches?
+   * Do we have any mismatches or unlocked?
    */
-  const hasMismatches = filtered.deps.length > 0
-                          || filtered.devDeps.length > 0;
+  const hasMismatches = filteredMatching.deps.length > 0
+                          || filteredMatching.devDeps.length > 0;
+
+  const hasUnlocked = filteredUnlocked.deps.length > 0
+                        || filteredUnlocked.devDeps.length > 0;
 
   /*
    * We have no mismatching packages, so lets
    * render the table and a nice message
    */
-  if (!hasMismatches) {
-    console.log(chalk.bold.bgGreen(' NPM Vet: No mismatched package versions \n'));
-
-    inlineTableRenderer(depMap);
-    process.exit(0);
+  if (!cliOpts.strict && !hasMismatches) {
+    sendSuccessResponse(depMap, ' NPM Vet: No mismatched package versions ');
   }
 
   /*
-   * Render an error message and a table with only
-   *  the mismatching verisons shown
+   * If we're in strict mode, and nothing is unlocked,
+   * then render the table and a nice message.
    */
-  const mismatchingLength = filtered.deps.length + filtered.devDeps.length;
-  const phrase            = mismatchingLength > 1
-                              ? pluralize('package')
-                              : 'package';
+  if (cliOpts.strict && !hasUnlocked) {
+    sendSuccessResponse(depMap, ' NPM Vet: No unlocked packages or mismatched package versions ');
+  }
 
-  console.log(chalk.bold.bgRed(` NPM Vet: You have ${mismatchingLength} ${phrase} `
-                               + `with mismatched versions \n`));
+  /*
+   * Whenever we get here, we either have no
+   * some mismatches or some unlocked packages
+   * in strict mode.
+   */
+  const mismatchingLength = filteredMatching.deps.length + filteredMatching.devDeps.length;
+  const unlockedLength    = filteredUnlocked.deps.length + filteredUnlocked.devDeps.length;
 
-  inlineTableRenderer(filtered);
+  const phrase = mismatchingLength > 1
+                  ? pluralize('package')
+                  : 'package';
+
+  /*
+   * Render an error message and a table with only
+   * the mismatching verisons shown if any mismatches
+   * are there.
+   */
+  if (mismatchingLength > 0) {
+    sendErrorResponse(filteredMatching, ` NPM Vet: You have ${mismatchingLength} ${phrase} `
+                                        + `with mismatched versions `);
+  }
+
+  /*
+   * We must be in strict mode with some unlocked
+   * packages, lets fail.
+   */
+  sendErrorResponse(filteredUnlocked, ` NPM Vet: You have ${unlockedLength} ${phrase} `
+                                        + `that are currently unlocked versions `);
+};
+
+/**
+ * @param  {IPackageDescriptorMap} depMap
+ * @param  {string} message
+ */
+let sendSuccessResponse = (depMap: IPackageDescriptorMap, message: string) =>
+{
+  console.log(chalk.bold.bgGreen(message));
+
+  inlineTableRenderer(depMap);
+  process.exit(0);
+};
+
+/**
+ * @param  {IPackageDescriptorMap} filteredMatching
+ * @param  {string} message
+ */
+let sendErrorResponse = (filteredMatching: IPackageDescriptorMap, message: string) =>
+{
+  console.log(chalk.bold.bgRed(message));
+
+  inlineTableRenderer(filteredMatching);
   process.exit(1);
 };
 
@@ -53,3 +105,10 @@ export const render: IRenderer = (depMap) =>
  */
 let filterMatchingDependencies = (deps: IPackageDescriptor[]): IPackageDescriptor[] =>
   deps.filter(d => !isMatchingVersion(d.parsedDefinedVersion, d.installedVersion));
+
+/**
+ * @param  {IPackageDescriptor[]} deps
+ * @returns IPackageDescriptor
+ */
+let filterLockedDependencies = (deps: IPackageDescriptor[]): IPackageDescriptor[] =>
+  deps.filter(d => !d.locked);

--- a/test/tests/cliopts/getCLIOptionsTest.js
+++ b/test/tests/cliopts/getCLIOptionsTest.js
@@ -19,7 +19,8 @@ describe('cliopts.getCLIOptions', () =>
     var expected = {
       package  : 'Cady',
       modules  : 'Regina',
-      renderer : 'Gretchen'
+      renderer : 'Gretchen',
+      strict   : false
     };
 
     expect(cliopts.getCLIOptions(input)).toEqual(expected);


### PR DESCRIPTION
- Add new CLI option (strict) to fail CI builds if packages are left unlocked, not just mismatched. (#19)
- Fixes bug where CI builds would have colour for more than the text line.