### PR TITLE
 Add support for git+ssh url dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
   "dependencies": {
     "blessed": "^0.1.81",
     "chalk": "^1.1.3",
-    "commander": "^2.9.0",
+    "commander": "2.9.0",
     "lodash": "^4.17.4",
     "pluralize": "^3.1.0",
     "semver": "^5.3.0",

--- a/src/deps.ts
+++ b/src/deps.ts
@@ -40,6 +40,7 @@ export function toDependencies(object: {}): IDependency[]
  */
 export function parseVersion(version: string): string
 {
+  // Tests for whether the version starts with ~ (tilde) or ^ (caret)
   if (/^[~^]/.test(version)) {
     return version.substring(1);
   }
@@ -53,14 +54,16 @@ export function parseVersion(version: string): string
  */
 export function extractVersionFromUrl(version: string) : string
 {
+  // Regex for checking whether this version references a git ssh url
   const regex = /(?:git|ssh|https?|git@[-\w.]+):(\/\/)?(.*?)(\.git)(\/?|\#[-\d\w._]+?)$/
   if (regex.test(version)) {
+    // If a version number is present, then return that version number, else return 'Unknown'
     var i = version.indexOf('.git#v');
     if (i > 0) {
       return version.substring(i+6);
     }
     else {
-      return 'unknown';
+      return 'Unknown';
     }
   }
   return version;

--- a/src/deps.ts
+++ b/src/deps.ts
@@ -40,12 +40,31 @@ export function toDependencies(object: {}): IDependency[]
  */
 export function parseVersion(version: string): string
 {
-  if (!/^[~^]/.test(version)) {
-    return version;
+  if (/^[~^]/.test(version)) {
+    return version.substring(1);
   }
 
-  return version.substring(1);
+  return extractVersionFromUrl(version);
 };
+
+/**
+ * @param  {string} version
+ * @returns string
+ */
+export function extractVersionFromUrl(version: string) : string
+{
+  const regex = /(?:git|ssh|https?|git@[-\w.]+):(\/\/)?(.*?)(\.git)(\/?|\#[-\d\w._]+?)$/
+  if (regex.test(version)) {
+    var i = version.indexOf('.git#v');
+    if (i > 0) {
+      return version.substring(i+6);
+    }
+    else {
+      return 'unknown';
+    }
+  }
+  return version;
+}
 
 /**
  * @param  {IDependency} dep

--- a/src/deps.ts
+++ b/src/deps.ts
@@ -74,11 +74,11 @@ export function dependencyToPackageDescriptor(dep: IDependency): IPackageDescrip
 {
   let packageDescriptor: IPackageDescriptor = {
     name                 : dep.name,
-    definedVersion       : dep.version,
+    definedVersion       : extractVersionFromUrl(dep.version),
     parsedDefinedVersion : parseVersion(dep.version),
     installedVersion     : null,
     installed            : false,
-    locked               : semver.clean(dep.version) !== null
+    locked               : semver.clean(extractVersionFromUrl(dep.version)) !== null
   };
 
   return packageDescriptor;

--- a/test/tests/deps/extractVersionFromUrlTest.js
+++ b/test/tests/deps/extractVersionFromUrlTest.js
@@ -8,7 +8,7 @@ describe('deps.extractVersionFromUrlTest', () =>
     var deps = require(SRC_DIRECTORY + '/deps');
 
     expect(deps.extractVersionFromUrl('git+ssh://git@git.testing.abc:test-group/testmodule.git#v1.3.2')).toBe('1.3.2');
-    expect(deps.extractVersionFromUrl('git+ssh://git@git.testing.abc:test-group/testmodule.git')).toBe('unknown');
+    expect(deps.extractVersionFromUrl('git+ssh://git@git.testing.abc:test-group/testmodule.git')).toBe('Unknown');
   });
 
 });

--- a/test/tests/deps/extractVersionFromUrlTest.js
+++ b/test/tests/deps/extractVersionFromUrlTest.js
@@ -1,0 +1,14 @@
+jest.dontMock(SRC_DIRECTORY + '/deps');
+
+describe('deps.extractVersionFromUrlTest', () =>
+{
+
+  it('Should extract version correctly from Url', () =>
+  {
+    var deps = require(SRC_DIRECTORY + '/deps');
+
+    expect(deps.extractVersionFromUrl('git+ssh://git@git.testing.abc:test-group/testmodule.git#v1.3.2')).toBe('1.3.2');
+    expect(deps.extractVersionFromUrl('git+ssh://git@git.testing.abc:test-group/testmodule.git')).toBe('unknown');
+  });
+
+});

--- a/test/tests/deps/parseVersionTest.js
+++ b/test/tests/deps/parseVersionTest.js
@@ -10,6 +10,8 @@ describe('deps.parseVersion', () =>
     expect(deps.parseVersion('1.0.0')).toBe('1.0.0');
     expect(deps.parseVersion('~1.0.0')).toBe('1.0.0');
     expect(deps.parseVersion('^1.0.0')).toBe('1.0.0');
+    expect(deps.parseVersion('git+ssh://git@git.testing.abc:test-group/testmodule.git#v1.0.0')).toBe('1.0.0');
+    expect(deps.parseVersion('git+ssh://git@git.testing.abc:test-group/testmodule.git')).toBe('unknown');
   });
 
 });

--- a/test/tests/deps/parseVersionTest.js
+++ b/test/tests/deps/parseVersionTest.js
@@ -11,7 +11,7 @@ describe('deps.parseVersion', () =>
     expect(deps.parseVersion('~1.0.0')).toBe('1.0.0');
     expect(deps.parseVersion('^1.0.0')).toBe('1.0.0');
     expect(deps.parseVersion('git+ssh://git@git.testing.abc:test-group/testmodule.git#v1.0.0')).toBe('1.0.0');
-    expect(deps.parseVersion('git+ssh://git@git.testing.abc:test-group/testmodule.git')).toBe('unknown');
+    expect(deps.parseVersion('git+ssh://git@git.testing.abc:test-group/testmodule.git')).toBe('Unknown');
   });
 
 });


### PR DESCRIPTION
Support for git+ssh module dependencies. E.g:

`"test-module": "git+ssh://git@git.testing.abc:test-group/test-module.git#v1.0.0"`