### PR TITLE
Feature/handle vless versions

### DIFF
--- a/src/deps.ts
+++ b/src/deps.ts
@@ -58,12 +58,17 @@ export function extractVersionFromUrl(version: string) : string
   const regex = /(?:git|ssh|https?|git@[-\w.]+):(\/\/)?(.*?)(\.git)(\/?|\#[-\d\w._]+?)$/
   if (regex.test(version)) {
     // If a version number is present, then return that version number, else return 'Unknown'
-    var i = version.indexOf('.git#v');
-    if (i > 0) {
-      return version.substring(i+6);
+
+    // get the last group which is the #versionspec at the end
+    let lastGroup = version.match(regex)[4];
+    if(!lastGroup) {
+      return "Unknown"; //no #versionspec
     }
-    else {
-      return 'Unknown';
+    let versionTag = lastGroup.replace('#', ''); //strip off the '#'
+    if (versionTag.indexOf('v') == 0) {
+      return versionTag.substring(1); //strip off the leading 'v' if present
+    } else {
+      return versionTag;
     }
   }
   return version;

--- a/test/tests/deps/extractVersionFromUrlTest.js
+++ b/test/tests/deps/extractVersionFromUrlTest.js
@@ -10,6 +10,7 @@ describe('deps.extractVersionFromUrlTest', () =>
     expect(deps.extractVersionFromUrl('git+ssh://git@git.testing.abc:test-group/testmodule.git#1.3.2')).toBe('1.3.2');
     expect(deps.extractVersionFromUrl('git+ssh://git@git.testing.abc:test-group/testmodule.git#v1.3.2')).toBe('1.3.2');
     expect(deps.extractVersionFromUrl('git+ssh://git@git.testing.abc:test-group/testmodule.git')).toBe('Unknown');
+    expect(deps.extractVersionFromUrl('anythingelse')).toBe('anythingelse');
   });
 
 });

--- a/test/tests/deps/extractVersionFromUrlTest.js
+++ b/test/tests/deps/extractVersionFromUrlTest.js
@@ -7,6 +7,7 @@ describe('deps.extractVersionFromUrlTest', () =>
   {
     var deps = require(SRC_DIRECTORY + '/deps');
 
+    expect(deps.extractVersionFromUrl('git+ssh://git@git.testing.abc:test-group/testmodule.git#1.3.2')).toBe('1.3.2');
     expect(deps.extractVersionFromUrl('git+ssh://git@git.testing.abc:test-group/testmodule.git#v1.3.2')).toBe('1.3.2');
     expect(deps.extractVersionFromUrl('git+ssh://git@git.testing.abc:test-group/testmodule.git')).toBe('Unknown');
   });


### PR DESCRIPTION
Closes #26 

Handle version tags that don't start with 'v' in a git URL.