### PR TITLE
Fix Command Line Argument Parsing

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -31,7 +31,7 @@ program
  * validate that the package.json file and
  * node_modules folder exists.
  */
-const opts = getCLIOptions(program.parse(process.argv));
+const opts = getCLIOptions(program.parse().opts());
 const paths = makeVetPaths(opts);
 
 if (!fileExists(paths.packagePath)) {


### PR DESCRIPTION
The `commander` dependency was upgraded from 2.9.0 to 9.1.0 in v0.2.0, which changed the way options are accessed.